### PR TITLE
Fix broken test that was using jasmine-jquery spyOnEvent

### DIFF
--- a/build/config/karma.conf.js
+++ b/build/config/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config){
 
     autoWatch : true,
 
-    frameworks: [ 'jasmine-jquery', 'jasmine'],
+    frameworks: [ 'jasmine'],
 
     browsers : ['Chrome'],
 
@@ -28,8 +28,7 @@ module.exports = function(config){
             'karma-firefox-launcher',
             'karma-script-launcher',
             'karma-spec-reporter',
-            'karma-jasmine',
-            'karma-jasmine-jquery'
+            'karma-jasmine'
             ]
   });
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "karma": "^0.12.28",
     "karma-chrome-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.3",
-    "karma-jasmine-jquery": "^0.1.1",
     "karma-script-launcher": "^0.1.0",
     "karma-spec-reporter": "0.0.16"
   }

--- a/test/nga11ymodal.js
+++ b/test/nga11ymodal.js
@@ -90,7 +90,10 @@ describe('ngA11y modal', function() {
 		$rootScope.$digest();
 
 		// spy on the closer's click event
-		var spy = spyOnEvent('#closer', 'click');
+		var clicked = false;
+		window.angular.element('#closer').on('click', function() {
+			clicked = true;
+		});
 
 		// fire an esc keypress
 		fireKey(element[0], 27);
@@ -98,7 +101,7 @@ describe('ngA11y modal', function() {
 		// the click isn't fired on the same cycle of the
 		// js engine - so we have to put a timeout here - ugh
 		setTimeout(function() {
-			expect(spy).toHaveBeenTriggered();
+			expect(clicked).toBe(true);
 			document.body.removeChild(element[0]);
 			done();
 		}, 1000);


### PR DESCRIPTION
I can't explain it - I had it working fine, until I merged.

I've removed the dependency on jasmine-jquery which I was only using the spyOnEvent, just putting in my own simple spy resolved this.

Bizarre. 